### PR TITLE
Add GraphQL queries for the Account entity

### DIFF
--- a/app/GraphQL/Query/AccountQuery.php
+++ b/app/GraphQL/Query/AccountQuery.php
@@ -23,6 +23,7 @@ final class AccountQuery extends Query
         return [
             'id' => ['name' => 'id', 'type' => Type::id()],
             'alias' => ['name' => 'alias', 'type' => Type::string()],
+            'publicKey' => ['name' => 'publicKey', 'type' => Type::string()],
         ];
     }
 
@@ -34,6 +35,10 @@ final class AccountQuery extends Query
 
         if (isset($args['alias'])) {
             return Account::findByAlias($args['alias']);
+        }
+
+        if (isset($args['publicKey'])) {
+            return Account::query()->where('public_key', $args['publicKey'])->first();
         }
 
         return null;

--- a/app/GraphQL/Query/AccountQuery.php
+++ b/app/GraphQL/Query/AccountQuery.php
@@ -28,7 +28,6 @@ final class AccountQuery extends Query
 
     public function resolve($root, $args)
     {
-
         if (isset($args['id'])) {
             return Account::query()->find($args['id']);
         }

--- a/app/GraphQL/Query/AccountQuery.php
+++ b/app/GraphQL/Query/AccountQuery.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\GraphQL\Query;
+
+use App\Account;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Query;
+
+final class AccountQuery extends Query
+{
+    protected $attributes = [
+        'name' => 'Account query',
+    ];
+
+    public function type()
+    {
+        return GraphQL::paginate('accounts');
+    }
+
+    public function args(): array
+    {
+        return [
+            'id' => ['name' => 'id', 'type' => Type::id()],
+            'alias' => ['name' => 'alias', 'type' => Type::string()],
+        ];
+    }
+
+    public function resolve($root, $args)
+    {
+        if (isset($args['id'])) {
+            return Account::query()->find($args['id']);
+        }
+
+        if (isset($args['alias'])) {
+            return Account::findByAlias($args['alias']);
+        }
+
+        return Account::query()->paginate($args['limit'], ['*'], 'page', $args['page']);
+    }
+}

--- a/app/GraphQL/Query/AccountQuery.php
+++ b/app/GraphQL/Query/AccountQuery.php
@@ -4,19 +4,18 @@ namespace App\GraphQL\Query;
 
 use App\Account;
 use GraphQL\Type\Definition\Type;
-use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Support\Query;
 
-final class AccountsQuery extends Query
+final class AccountQuery extends Query
 {
     protected $attributes = [
-        'name' => 'Accounts query',
+        'name' => 'Account query',
     ];
 
     public function type()
     {
-        return GraphQL::type('Account');
+        return GraphQL::paginate('Account');
     }
 
     public function args(): array
@@ -27,8 +26,17 @@ final class AccountsQuery extends Query
         ];
     }
 
-    public function resolve($root, $args): LengthAwarePaginator
+    public function resolve($root, $args)
     {
-        return Account::query()->paginate($args['limit'], ['*'], 'page', $args['page']);
+
+        if (isset($args['id'])) {
+            return Account::query()->find($args['id']);
+        }
+
+        if (isset($args['alias'])) {
+            return Account::findByAlias($args['alias']);
+        }
+
+        return null;
     }
 }

--- a/app/GraphQL/Query/AccountQuery.php
+++ b/app/GraphQL/Query/AccountQuery.php
@@ -15,7 +15,7 @@ final class AccountQuery extends Query
 
     public function type()
     {
-        return GraphQL::paginate('Account');
+        return GraphQL::type('Account');
     }
 
     public function args(): array

--- a/app/GraphQL/Query/AccountsQuery.php
+++ b/app/GraphQL/Query/AccountsQuery.php
@@ -3,7 +3,6 @@
 namespace App\GraphQL\Query;
 
 use App\Account;
-use GraphQL\Type\Definition\Type;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Support\Query;
@@ -16,15 +15,7 @@ final class AccountsQuery extends Query
 
     public function type()
     {
-        return GraphQL::type('Account');
-    }
-
-    public function args(): array
-    {
-        return [
-            'id' => ['name' => 'id', 'type' => Type::id()],
-            'alias' => ['name' => 'alias', 'type' => Type::string()],
-        ];
+        return GraphQL::paginate('Account');
     }
 
     public function resolve($root, $args): LengthAwarePaginator

--- a/app/GraphQL/Query/AccountsQuery.php
+++ b/app/GraphQL/Query/AccountsQuery.php
@@ -10,6 +10,9 @@ use Rebing\GraphQL\Support\Query;
 
 final class AccountsQuery extends Query
 {
+    private const DEFAULT_LIMIT = 15;
+    private const DEFAULT_PAGE = 1;
+
     protected $attributes = [
         'name' => 'Accounts query',
     ];
@@ -29,6 +32,11 @@ final class AccountsQuery extends Query
 
     public function resolve($root, $args): LengthAwarePaginator
     {
-        return Account::query()->paginate($args['limit'], ['*'], 'page', $args['page']);
+        return Account::query()->paginate(
+            $args['limit'] ?? self::DEFAULT_LIMIT,
+            ['*'],
+            'page',
+            $args['page'] ?? self::DEFAULT_PAGE
+        );
     }
 }

--- a/app/GraphQL/Query/AccountsQuery.php
+++ b/app/GraphQL/Query/AccountsQuery.php
@@ -3,6 +3,7 @@
 namespace App\GraphQL\Query;
 
 use App\Account;
+use GraphQL\Type\Definition\Type;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Support\Query;
@@ -16,6 +17,14 @@ final class AccountsQuery extends Query
     public function type()
     {
         return GraphQL::paginate('Account');
+    }
+
+    public function args(): array
+    {
+        return [
+            'page' => ['name' => 'page', 'type' => Type::int()],
+            'limit' => ['name' => 'limit', 'type' => Type::int()],
+        ];
     }
 
     public function resolve($root, $args): LengthAwarePaginator

--- a/app/GraphQL/Query/AccountsQuery.php
+++ b/app/GraphQL/Query/AccountsQuery.php
@@ -7,10 +7,10 @@ use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Support\Query;
 
-final class AccountQuery extends Query
+final class AccountsQuery extends Query
 {
     protected $attributes = [
-        'name' => 'Account query',
+        'name' => 'Accounts query',
     ];
 
     public function type()

--- a/app/GraphQL/Type/AccountType.php
+++ b/app/GraphQL/Type/AccountType.php
@@ -23,9 +23,13 @@ final class AccountType extends GraphQLType
                 'description' => 'The id or address of the account',
             ],
 
-            'public_key' => [
+            'publicKey' => [
                 'type' => Type::string(),
                 'description' => 'The public key registered with the account',
+                'alias' => 'public_key',
+                'resolve' => function ($root) {
+                    return $root->public_key;
+                },
             ],
 
             'block' => [

--- a/app/GraphQL/Type/AccountType.php
+++ b/app/GraphQL/Type/AccountType.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\GraphQL\Type;
+
+use App\Account;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Type as GraphQLType;
+
+final class AccountType extends GraphQLType
+{
+    protected $attributes = [
+        'name' => 'Account',
+        'description' => 'An account',
+        'model' => Account::class,
+    ];
+
+    public function fields(): array
+    {
+        return [
+
+            'id' => [
+                'type' => Type::nonNull(Type::id()),
+                'description' => 'The id or address of the account',
+            ],
+
+            'public_key' => [
+                'type' => Type::string(),
+                'description' => 'The public key registered with the account',
+            ],
+
+            'block' => [
+                'type' => Type::nonNull(Type::string()),
+                'description' => 'The block id that the account was created on',
+            ],
+
+            'balance' => [
+                'type' => Type::nonNull(Type::float()),
+                'description' => 'The current balance of the account',
+            ],
+
+            'alias' => [
+                'type' => Type::string(),
+                'description' => 'The alias registered with the account',
+            ],
+
+        ];
+    }
+}

--- a/config/graphql.php
+++ b/config/graphql.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\GraphQL\Controllers\LumenGraphQLController;
+use App\GraphQL\Query\AccountsQuery;
+use App\GraphQL\Type\AccountType;
 use App\Http\Middleware\PreconditionHeaderMiddleware;
 use Rebing\GraphQL\GraphQL;
 use Rebing\GraphQL\Support\PaginationType;
@@ -44,7 +46,9 @@ return [
 
     'schemas' => [
         'default' => [
-            'query' => [],
+            'query' => [
+                'accounts' => AccountsQuery::class,
+            ],
             'mutation' => [],
             'middleware' => [],
             'method' => ['post'],
@@ -54,7 +58,9 @@ return [
     // The types available in the application. You can then access it from the facade like this:
     // GraphQL::type('user')
 
-    'types' => [],
+    'types' => [
+        'Account' => AccountType::class,
+    ],
 
     // This callable will be passed the Error object for each errors GraphQL catch.
     // The method should return an array representing the error.

--- a/config/graphql.php
+++ b/config/graphql.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\GraphQL\Controllers\LumenGraphQLController;
+use App\GraphQL\Query\AccountQuery;
 use App\GraphQL\Query\AccountsQuery;
 use App\GraphQL\Type\AccountType;
 use App\Http\Middleware\PreconditionHeaderMiddleware;
@@ -47,6 +48,7 @@ return [
     'schemas' => [
         'default' => [
             'query' => [
+                'account' => AccountQuery::class,
                 'accounts' => AccountsQuery::class,
             ],
             'mutation' => [],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds 2 new `Account` entity queries for the GraphQL API.

**`account`**

```graphql
{
  account(id: "...", alias: "pxgamer") {
      id
      alias
      balance
      block
      publicKey
  }
}
```

**`accounts`**

```graphql
{
  accounts(page: 1, limit: 15) {
    data {
      id
      alias
      balance
      block
      publicKey
    }
  }
}
```

## Types of changes

Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
