### PR TITLE
Add GraphQL queries for the Block entity

### DIFF
--- a/app/GraphQL/Query/BlockQuery.php
+++ b/app/GraphQL/Query/BlockQuery.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\GraphQL\Query;
+
+use App\Block;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Query;
+
+final class BlockQuery extends Query
+{
+    protected $attributes = [
+        'name' => 'Block query',
+    ];
+
+    public function type()
+    {
+        return GraphQL::type('Block');
+    }
+
+    public function args(): array
+    {
+        return [
+            'id' => ['name' => 'id', 'type' => Type::id()],
+        ];
+    }
+
+    public function resolve($root, $args)
+    {
+        if (isset($args['id'])) {
+            return Block::query()->find($args['id']);
+        }
+
+        return null;
+    }
+}

--- a/app/GraphQL/Query/BlocksQuery.php
+++ b/app/GraphQL/Query/BlocksQuery.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\GraphQL\Query;
+
+use App\Block;
+use GraphQL\Type\Definition\Type;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Query;
+
+final class BlocksQuery extends Query
+{
+    private const DEFAULT_LIMIT = 15;
+    private const DEFAULT_PAGE = 1;
+
+    protected $attributes = [
+        'name' => 'Blocks query',
+    ];
+
+    public function type()
+    {
+        return GraphQL::paginate('Block');
+    }
+
+    public function args(): array
+    {
+        return [
+            'page' => ['name' => 'page', 'type' => Type::int()],
+            'limit' => ['name' => 'limit', 'type' => Type::int()],
+        ];
+    }
+
+    public function resolve($root, $args): LengthAwarePaginator
+    {
+        return Block::query()->paginate(
+            $args['limit'] ?? self::DEFAULT_LIMIT,
+            ['*'],
+            'page',
+            $args['page'] ?? self::DEFAULT_PAGE
+        );
+    }
+}

--- a/app/GraphQL/Type/BlockType.php
+++ b/app/GraphQL/Type/BlockType.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\GraphQL\Type;
+
+use App\Block;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Type as GraphQLType;
+
+final class BlockType extends GraphQLType
+{
+    protected $attributes = [
+        'name' => 'Block',
+        'description' => 'A block',
+        'model' => Block::class,
+    ];
+
+    public function fields(): array
+    {
+        return [
+
+            'id' => [
+                'type' => Type::nonNull(Type::id()),
+                'description' => 'The id of the block',
+            ],
+
+            'generator' => [
+                'type' => Type::nonNull(Type::string()),
+                'description' => 'The account id that generated the block',
+            ],
+
+            'height' => [
+                'type' => Type::nonNull(Type::int()),
+                'description' => 'The height of the block',
+            ],
+
+            'date' => [
+                'type' => Type::nonNull(Type::string()),
+                'description' => 'The date that the block was created on',
+            ],
+
+            'nonce' => [
+                'type' => Type::nonNull(Type::string()),
+                'description' => 'The nonce registered with the block',
+            ],
+
+            'signature' => [
+                'type' => Type::nonNull(Type::string()),
+                'description' => 'The signature registered with the block',
+            ],
+
+            'difficulty' => [
+                'type' => Type::nonNull(Type::int()),
+                'description' => 'The difficulty registered with the block',
+            ],
+
+            'argon' => [
+                'type' => Type::nonNull(Type::string()),
+                'description' => 'The argon generation data registered with the block',
+            ],
+
+            'transactions' => [
+                'type' => Type::nonNull(Type::int()),
+                'description' => 'The number of transactions registered with the block',
+            ],
+
+        ];
+    }
+}

--- a/config/graphql.php
+++ b/config/graphql.php
@@ -1,6 +1,9 @@
 <?php
 
 use App\GraphQL\Controllers\LumenGraphQLController;
+use App\GraphQL\Query\BlockQuery;
+use App\GraphQL\Query\BlocksQuery;
+use App\GraphQL\Type\BlockType;
 use App\Http\Middleware\PreconditionHeaderMiddleware;
 use Rebing\GraphQL\GraphQL;
 use Rebing\GraphQL\Support\PaginationType;
@@ -44,7 +47,10 @@ return [
 
     'schemas' => [
         'default' => [
-            'query' => [],
+            'query' => [
+                'block' => BlockQuery::class,
+                'blocks' => BlocksQuery::class,
+            ],
             'mutation' => [],
             'middleware' => [],
             'method' => ['post'],
@@ -54,7 +60,9 @@ return [
     // The types available in the application. You can then access it from the facade like this:
     // GraphQL::type('user')
 
-    'types' => [],
+    'types' => [
+        'Block' => BlockType::class,
+    ],
 
     // This callable will be passed the Error object for each errors GraphQL catch.
     // The method should return an array representing the error.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds 2 new `Block` entity queries for the GraphQL API.

**`block`**

```graphql
{
  block(id: "...") {
    id
    generator
    height
    date
    nonce
    signature
    difficulty
    argon
    transactions
  }
}
```

**`blocks`**

```graphql
{
  blocks(page: 1, limit: 15) {
    data {
      id
      generator
      height
      date
      nonce
      signature
      difficulty
      argon
      transactions
    }
  }
}
```

## Types of changes

Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
