### PR TITLE
Add GraphQL queries for the Masternode entity

### DIFF
--- a/app/GraphQL/Query/MasternodeQuery.php
+++ b/app/GraphQL/Query/MasternodeQuery.php
@@ -21,14 +21,19 @@ final class MasternodeQuery extends Query
     public function args(): array
     {
         return [
-            'public_key' => ['name' => 'public_key', 'type' => Type::nonNull(Type::string())],
+            'publicKey' => ['name' => 'publicKey', 'type' => Type::string()],
+            'ip' => ['name' => 'ip', 'type' => Type::string()],
         ];
     }
 
     public function resolve($root, $args)
     {
-        if (isset($args['public_key'])) {
-            return Masternode::query()->find($args['public_key']);
+        if (isset($args['publicKey'])) {
+            return Masternode::query()->find($args['publicKey']);
+        }
+
+        if (isset($args['ip'])) {
+            return Masternode::query()->where('ip', $args['ip'])->first();
         }
 
         return null;

--- a/app/GraphQL/Query/MasternodeQuery.php
+++ b/app/GraphQL/Query/MasternodeQuery.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\GraphQL\Query;
+
+use App\Masternode;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Query;
+
+final class MasternodeQuery extends Query
+{
+    protected $attributes = [
+        'name' => 'Masternode query',
+    ];
+
+    public function type()
+    {
+        return GraphQL::type('Masternode');
+    }
+
+    public function args(): array
+    {
+        return [
+            'public_key' => ['name' => 'public_key', 'type' => Type::nonNull(Type::string())],
+        ];
+    }
+
+    public function resolve($root, $args)
+    {
+        if (isset($args['public_key'])) {
+            return Masternode::query()->find($args['public_key']);
+        }
+
+        return null;
+    }
+}

--- a/app/GraphQL/Query/MasternodesQuery.php
+++ b/app/GraphQL/Query/MasternodesQuery.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\GraphQL\Query;
+
+use App\Masternode;
+use GraphQL\Type\Definition\Type;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Query;
+
+final class MasternodesQuery extends Query
+{
+    private const DEFAULT_LIMIT = 15;
+    private const DEFAULT_PAGE = 1;
+
+    protected $attributes = [
+        'name' => 'Masternodes query',
+    ];
+
+    public function type()
+    {
+        return GraphQL::paginate('Masternode');
+    }
+
+    public function args(): array
+    {
+        return [
+            'page' => ['name' => 'page', 'type' => Type::int()],
+            'limit' => ['name' => 'limit', 'type' => Type::int()],
+        ];
+    }
+
+    public function resolve($root, $args): LengthAwarePaginator
+    {
+        return Masternode::query()->paginate(
+            $args['limit'] ?? self::DEFAULT_LIMIT,
+            ['*'],
+            'page',
+            $args['page'] ?? self::DEFAULT_PAGE
+        );
+    }
+}

--- a/app/GraphQL/Type/MasternodeType.php
+++ b/app/GraphQL/Type/MasternodeType.php
@@ -35,7 +35,7 @@ final class MasternodeType extends GraphQLType
             ],
 
             'lastWon' => [
-                'type' => Type::nonNull(Type::int()),
+                'type' => Type::int(),
                 'description' => 'The height of the last block that the masternode won',
                 'alias' => 'last_won',
             ],

--- a/app/GraphQL/Type/MasternodeType.php
+++ b/app/GraphQL/Type/MasternodeType.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\GraphQL\Type;
+
+use App\Masternode;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Type as GraphQLType;
+
+final class MasternodeType extends GraphQLType
+{
+    protected $attributes = [
+        'name' => 'Masternode',
+        'description' => 'A masternode',
+        'model' => Masternode::class,
+    ];
+
+    public function fields(): array
+    {
+        return [
+
+            'publicKey' => [
+                'type' => Type::nonNull(Type::string()),
+                'description' => 'The public key of the masternode',
+                'alias' => 'public_key',
+            ],
+
+            'height' => [
+                'type' => Type::nonNull(Type::int()),
+                'description' => 'The block height that the masternode was created on',
+            ],
+
+            'ip' => [
+                'type' => Type::nonNull(Type::string()),
+                'description' => 'The IP address registered with the masternode',
+            ],
+
+            'lastWon' => [
+                'type' => Type::nonNull(Type::int()),
+                'description' => 'The height of the last block that the masternode won',
+                'alias' => 'last_won',
+            ],
+
+            'blacklist' => [
+                'type' => Type::int(),
+                'description' => 'The timestamp that the masternode was last blacklisted',
+            ],
+
+            'fails' => [
+                'type' => Type::int(),
+                'description' => 'The number of failed requests for the masternode',
+            ],
+
+            'status' => [
+                'type' => Type::int(),
+                'description' => 'The current status of the masternode',
+            ],
+
+        ];
+    }
+}

--- a/app/GraphQL/Type/MasternodeType.php
+++ b/app/GraphQL/Type/MasternodeType.php
@@ -22,6 +22,9 @@ final class MasternodeType extends GraphQLType
                 'type' => Type::nonNull(Type::string()),
                 'description' => 'The public key of the masternode',
                 'alias' => 'public_key',
+                'resolve' => function ($root) {
+                    return $root->public_key;
+                },
             ],
 
             'height' => [
@@ -38,6 +41,9 @@ final class MasternodeType extends GraphQLType
                 'type' => Type::int(),
                 'description' => 'The height of the last block that the masternode won',
                 'alias' => 'last_won',
+                'resolve' => function ($root) {
+                    return $root->last_won;
+                },
             ],
 
             'blacklist' => [

--- a/config/graphql.php
+++ b/config/graphql.php
@@ -1,6 +1,9 @@
 <?php
 
 use App\GraphQL\Controllers\LumenGraphQLController;
+use App\GraphQL\Query\MasternodeQuery;
+use App\GraphQL\Query\MasternodesQuery;
+use App\GraphQL\Type\MasternodeType;
 use App\Http\Middleware\PreconditionHeaderMiddleware;
 use Rebing\GraphQL\GraphQL;
 use Rebing\GraphQL\Support\PaginationType;
@@ -44,7 +47,10 @@ return [
 
     'schemas' => [
         'default' => [
-            'query' => [],
+            'query' => [
+                'masternode' => MasternodeQuery::class,
+                'masternodes' => MasternodesQuery::class,
+            ],
             'mutation' => [],
             'middleware' => [],
             'method' => ['post'],
@@ -54,7 +60,9 @@ return [
     // The types available in the application. You can then access it from the facade like this:
     // GraphQL::type('user')
 
-    'types' => [],
+    'types' => [
+        'Masternode' => MasternodeType::class
+    ],
 
     // This callable will be passed the Error object for each errors GraphQL catch.
     // The method should return an array representing the error.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds 2 new `Masternode` entity queries for the GraphQL API.

**`masternode`**

```graphql
{
  masternode(publicKey: "...", ip: "...") {
    publicKey
    height
    ip
    lastWon
    blacklist
    fails
    status
  }
}
```

**`masternodes`**

```graphql
{
  masternodes(page: 1, limit: 15) {
    data {
      publicKey
      height
      ip
      lastWon
      blacklist
      fails
      status
    }
  }
}
```

## Types of changes

Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
