### PR TITLE
Add GraphQL queries for the Mempool entity

### DIFF
--- a/app/GraphQL/Query/MempoolQuery.php
+++ b/app/GraphQL/Query/MempoolQuery.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\GraphQL\Query;
+
+use App\Mempool;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Query;
+
+final class MempoolQuery extends Query
+{
+    protected $attributes = [
+        'name' => 'Mempool query',
+    ];
+
+    public function type()
+    {
+        return GraphQL::type('Mempool');
+    }
+
+    public function args(): array
+    {
+        return [
+            'id' => ['name' => 'id', 'type' => Type::id()],
+        ];
+    }
+
+    public function resolve($root, $args)
+    {
+        if (isset($args['id'])) {
+            return Mempool::query()->find($args['id']);
+        }
+
+        return null;
+    }
+}

--- a/app/GraphQL/Query/MempoolsQuery.php
+++ b/app/GraphQL/Query/MempoolsQuery.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\GraphQL\Query;
+
+use App\Mempool;
+use GraphQL\Type\Definition\Type;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Query;
+
+final class MempoolsQuery extends Query
+{
+    private const DEFAULT_LIMIT = 15;
+    private const DEFAULT_PAGE = 1;
+
+    protected $attributes = [
+        'name' => 'Mempools query',
+    ];
+
+    public function type()
+    {
+        return GraphQL::paginate('Mempool');
+    }
+
+    public function args(): array
+    {
+        return [
+            'page' => ['name' => 'page', 'type' => Type::int()],
+            'limit' => ['name' => 'limit', 'type' => Type::int()],
+        ];
+    }
+
+    public function resolve($root, $args): LengthAwarePaginator
+    {
+        return Mempool::query()->paginate(
+            $args['limit'] ?? self::DEFAULT_LIMIT,
+            ['*'],
+            'page',
+            $args['page'] ?? self::DEFAULT_PAGE
+        );
+    }
+}

--- a/app/GraphQL/Type/MempoolType.php
+++ b/app/GraphQL/Type/MempoolType.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\GraphQL\Type;
+
+use App\Mempool;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Type as GraphQLType;
+
+final class MempoolType extends GraphQLType
+{
+    protected $attributes = [
+        'name' => 'Mempool',
+        'description' => 'A mempool transaction',
+        'model' => Mempool::class,
+    ];
+
+    public function fields(): array
+    {
+        return [
+
+            'id' => [
+                'type' => Type::nonNull(Type::id()),
+                'description' => 'The id of the mempool transaction',
+            ],
+
+            'height' => [
+                'type' => Type::int(),
+                'description' => 'The height of the mempool transaction',
+            ],
+
+            'src' => [
+                'type' => Type::nonNull(Type::string()),
+                'description' => 'The source address of the mempool transaction',
+            ],
+
+            'dst' => [
+                'type' => Type::nonNull(Type::string()),
+                'description' => 'The destination address of the mempool transaction',
+            ],
+
+            'val' => [
+                'type' => Type::nonNull(Type::float()),
+                'description' => 'The value of the mempool transaction',
+            ],
+
+            'fee' => [
+                'type' => Type::nonNull(Type::float()),
+                'description' => 'The fee total for the mempool transaction',
+            ],
+
+            'signature' => [
+                'type' => Type::nonNull(Type::string()),
+                'description' => 'The signature of the mempool transaction',
+            ],
+
+            'version' => [
+                'type' => Type::nonNull(Type::int()),
+                'description' => 'The version type for the mempool transaction',
+            ],
+
+            'message' => [
+                'type' => Type::string(),
+                'description' => 'The message for the mempool transaction',
+            ],
+
+            'publicKey' => [
+                'type' => Type::nonNull(Type::string()),
+                'description' => 'The public key for the source of the mempool transaction',
+                'alias' => 'public_key',
+                'resolve' => function ($root) {
+                    return $root->public_key;
+                },
+            ],
+
+            'peer' => [
+                'type' => Type::nonNull(Type::string()),
+                'description' => 'The peer address that the mempool transaction originated at',
+            ],
+
+        ];
+    }
+}

--- a/config/graphql.php
+++ b/config/graphql.php
@@ -1,6 +1,9 @@
 <?php
 
 use App\GraphQL\Controllers\LumenGraphQLController;
+use App\GraphQL\Query\MempoolQuery;
+use App\GraphQL\Query\MempoolsQuery;
+use App\GraphQL\Type\MempoolType;
 use App\Http\Middleware\PreconditionHeaderMiddleware;
 use Rebing\GraphQL\GraphQL;
 use Rebing\GraphQL\Support\PaginationType;
@@ -44,7 +47,10 @@ return [
 
     'schemas' => [
         'default' => [
-            'query' => [],
+            'query' => [
+                'mempool' => MempoolQuery::class,
+                'mempools' => MempoolsQuery::class,
+            ],
             'mutation' => [],
             'middleware' => [],
             'method' => ['post'],
@@ -54,7 +60,9 @@ return [
     // The types available in the application. You can then access it from the facade like this:
     // GraphQL::type('user')
 
-    'types' => [],
+    'types' => [
+        'Mempool' => MempoolType::class,
+    ],
 
     // This callable will be passed the Error object for each errors GraphQL catch.
     // The method should return an array representing the error.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds 2 new `Mempool` entity queries for the GraphQL API.

**`mempool`**

```graphql
{
  mempool(id: "...") {
    id
    height
    src
    dst
    val
    fee
    signature
    version
    message
    publicKey
    peer
  }
}
```

**`mempools`**

```graphql
{
  mempools(page: 1, limit: 15) {
    data {
      id
      height
      src
      dst
      val
      fee
      signature
      version
      message
      publicKey
      peer
    }
  }
}
```

## Types of changes

Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
