### PR TITLE
Remove PHP CodeSniffer and use only Style CI

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ We accept contributions via Pull Requests on [Github](https://github.com/pxgamer
 
 ## Pull Requests
 
-- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - Check the code style with ``$ composer check-style`` and fix it with ``$ composer fix-style``.
+- **Laravel Coding Standard** - This is automatically linted by [Style CI](https://styleci.io).
 
 - **Add tests!** - If possible, try to add tests to support your patch.
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ before_script:
 - travis_retry composer update --no-interaction --prefer-dist
 
 script:
-- vendor/bin/phpcs --standard=psr2 app/
 - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover --testdox
 
 after_success:

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
         "fzaninotto/faker": "^1.8",
         "mockery/mockery": "^1.2",
         "phpunit/phpunit": "^8.1",
-        "roave/security-advisories": "dev-master",
-        "squizlabs/php_codesniffer": "^3.4"
+        "roave/security-advisories": "dev-master"
     },
     "autoload": {
         "classmap": [
@@ -35,9 +34,7 @@
         "post-root-package-install": [
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
         ],
-        "test": "phpunit",
-        "check-style": "phpcs app tests",
-        "fix-style": "phpcbf app tests"
+        "test": "phpunit"
     },
     "config": {
         "preferred-install": "dist",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This removes local style checking via PHP CodeSniffer and utilises Style CI instead.

## Types of changes

Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
